### PR TITLE
docs(index.md): fix link style

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -35,7 +35,7 @@ Vitest 的主要优势之一是它与 Vite 拥有的统一配置。 如果有配
 - 将 `--config` 传递给 CLI, 例如： `vitest --config ./path/to/vitest.config.ts`
 - 使用 `process.env.VITEST` 有条件地在 `vite.config.ts` 中应用不同的配置。
 
-要配置 `Vitest`，需要在 Vite 配置中添加 `test` 属性。 还需要在配置文件顶部使用[三斜杠指令](https://www.tslang.cn/docs/handbook/triple-slash-directives.html#-reference-types-)添加对 Vitest 类型的引用。
+要配置 `Vitest`，需要在 Vite 配置中添加 `test` 属性。 还需要在配置文件顶部使用 [三斜杠指令](https://www.tslang.cn/docs/handbook/triple-slash-directives.html#-reference-types-) 添加对 Vitest 类型的引用。
 
 ```ts
 /// <reference types="vitest" />


### PR DESCRIPTION
Add spaces at both ends of the link