### PR TITLE
docs: remove config_interopDefault

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -240,10 +240,6 @@ test('use jsdom in this test file', () => {
 
 最小的线程数。
 
-### interopDefault
-
-- **类型:** `boolean`
-
 ### testTimeout
 
 - **类型:** `number`


### PR DESCRIPTION
vitest'doc https://vitest.dev/config/ does not support config `interopDefault` now